### PR TITLE
[bugfix] App freezing and default flag assigning

### DIFF
--- a/lib/data/show_notifier.dart
+++ b/lib/data/show_notifier.dart
@@ -94,7 +94,6 @@ class ShowNotifier extends InputBasic with ChangeNotifier {
                 track.flags['default']!.value = false;
               }
             }
-            break;
           }
         } else {
           track.flags['default']!.value = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,10 @@ void main() async {
     skipTaskbar: false,
     backgroundColor: Colors.transparent,
   );
-  await windowManager.waitUntilReadyToShow(windowOptions, () async {
+
+  // Causes app frame freeze on hot reload or hot restart so don't await this one.
+  // ignore: unawaited_futures
+  windowManager.waitUntilReadyToShow(windowOptions, () async {
     await windowManager.setPreventClose(true);
     await windowManager.show();
     // Handles default title bar theme changes at startup

--- a/lib/models/show.dart
+++ b/lib/models/show.dart
@@ -76,6 +76,7 @@ class Video extends TrackProperties {
 
   Future<void> loadInfo() async {
     info = await MetadataScanner.video(mainFile);
+    flags = info.videoInfo.first.flags;
 
     for (var audio in info.audioInfo) {
       embeddedAudios.add(


### PR DESCRIPTION
Fix:
- Fix app freezing when reloading/restarting in debug and on restoring app window in release mode
- Add the missing reference of embedded track flags data to the Video class' flags data
- Remove early exit from for-loop when programatically assigning default flag