### PR TITLE
fix: convert short uids to string

### DIFF
--- a/lib/models/mkv_info.dart
+++ b/lib/models/mkv_info.dart
@@ -78,8 +78,8 @@ class MkvTrackInfo {
 
   factory MkvTrackInfo.fromJson(Map<String, dynamic> json) {
     final props = json['properties'];
-    String? uid = props['uid'];
-    uid ??= json.hashCode.toString();
+    final uid = props['uid']?.toString() ?? json.hashCode.toString();
+
     return MkvTrackInfo(
       id: json['id'],
       uid: uid,


### PR DESCRIPTION
fix:
 -  Usually `UID`s are `Long Integer` so we had to use `preprocessJsonString` to convert it into `String` however there are instances that it uses a custom UID which starts in counting number for each track so it doesn't get converted into `String` but the declared variable for `UID` is a type of `String` so we have to force `toString` method to the fetched value.