### PR TITLE
fix: object keys for notifier widget state

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -284,8 +284,11 @@ class InfoPanel extends StatelessWidget {
             ),
           );
         }
+
+        final notifier = context.read<ShowListNotifier>().items[id]!;
         return ChangeNotifierProvider.value(
-          value: context.watch<ShowListNotifier>().items[id]!,
+          key: ObjectKey(notifier),
+          value: notifier,
           builder: (context, child) {
             return const MainNode();
           },


### PR DESCRIPTION
fix:
 - Current setup can't differentiate context of widget state\
which affects the data passed below the widget tree so we have to use ObjectKey for identification of each notifier