### PR TITLE
fix: Set enabled to true by default on added track

### DIFF
--- a/lib/models/show.dart
+++ b/lib/models/show.dart
@@ -389,6 +389,7 @@ class AddedTrack extends TrackProperties {
       }
 
       language = await AppData.languageCodes.identifyByText(file.title);
+      flags['enabled']!.value = true;
       flags['original_language']!.value = await _isOriginalLanguage;
       flags['forced']!.value = await _isForced;
       flags['commentary']!.value = await _isCommentary;


### PR DESCRIPTION
fix:
 - The `Flag` class has `value` set to `false` by default but the `enabled` flag should be set to `true` by default following mkvmerge specification.