### PR TITLE
Feature/default-flag-indicator-on-track-language

### DIFF
--- a/lib/models/track_properties.dart
+++ b/lib/models/track_properties.dart
@@ -93,7 +93,7 @@ abstract class TrackProperties {
 
   /// Specified flag names according to the list [flags] declarations.
   static List<String> flagNames = [
-    'enabled',
+    //'enabled', // Exclude Enabled since it can override default on playback.
     'default',
     'original_language',
     'forced',

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -111,7 +111,7 @@ class UserProfile extends ChangeNotifier with EquatableMixin {
         'HD',
         r'\b\d{4}\b', // Year
         r'Season.\d+|S.\d+|Season \d+|S \d+', // Season
-        r'Episode.\d+|E.\d+|Episode \d+|E \d+', // Episode
+        r'Episode.\d+|E.\d+|Episode \d+|E \d+|\b\d{2}\b', // Episode
         r'\d{3,4}p', //'1080p', '720p', '480p',
         r'x.\d{3}|x\d{3}', //'x.264', 'x.265', 'x264', 'x265',
         r'h.\d{3}|h\d{3}', //'h.264', //'h.265', 'h264', 'h265',

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1663,15 +1663,22 @@ class _TrackNodeState extends State<TrackNode> {
                     height: double.infinity,
                     decoration: BoxDecoration(
                       border: Border.all(
-                          color: theme.accentColor
-                              .defaultBrushFor(theme.brightness)),
+                        color: widget.track.flags['default']!.value
+                            ? theme.accentColor
+                                .defaultBrushFor(theme.brightness)
+                            : FluentTheme.of(context).inactiveColor,
+                      ),
                       borderRadius: BorderRadius.circular(4),
                     ),
                     child: Text(
                       widget.track.language.name,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 10,
                         fontWeight: FontWeight.w500,
+                        color: widget.track.flags['default']!.value
+                            ? theme.accentColor
+                                .defaultBrushFor(theme.brightness)
+                            : FluentTheme.of(context).inactiveColor,
                       ),
                     ),
                   ),

--- a/lib/screens/home/home_screen_dialogs.dart
+++ b/lib/screens/home/home_screen_dialogs.dart
@@ -443,7 +443,7 @@ class _TrackDialogState extends State<TrackDialog> {
   late final String? initialTitle = widget.track.title;
   late final titleCtrl = TextEditingController(text: initialTitle);
   late LanguageCode language = widget.track.language;
-  late final initialLanguage = language.cleanName;
+  late final initialLanguage = language.fullCleanName;
   late final languageCtrl = TextEditingController(text: initialLanguage);
   final languageNode = FocusNode();
   late final include = ValueNotifier(widget.track.include);
@@ -524,6 +524,7 @@ class _TrackDialogState extends State<TrackDialog> {
                     label: code.fullCleanName,
                     child: Text(
                       code.fullCleanName,
+                      maxLines: 1,
                       softWrap: false,
                       overflow: TextOverflow.fade,
                     ),


### PR DESCRIPTION
feat:
 - Default flag indicator using color of language in tracks

chore:
 - use fullCleanName of LanguageCode for TextEditingController
 - add the 00 pattern of episode in defaultModifiers
 - exclude include flag in flagNames used in Profile creation