### PR TITLE
fix: Existing modifier not being updated

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -203,7 +203,7 @@
       }
     }
   },
-  "replacementPreview": "{replacement, select, remove_string {Remove text} replace_with_whitespace {Replace with whitespace} other {replacement}}",
+  "replacementPreview": "{replacement, select, remove_string {Remove text} replace_with_whitespace {Replace with whitespace} other {{replacement}}}",
   "@replacementPreview": {
     "description": "Replacement preview by replacement",
     "placeholders": {

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -203,7 +203,7 @@
       }
     }
   },
-  "replacementPreview": "{replacement, select, remove_string {Tanggalin ang text} replace_with_whitespace {Palitan ng whitespace} other {replacement}}",
+  "replacementPreview": "{replacement, select, remove_string {Tanggalin ang text} replace_with_whitespace {Palitan ng whitespace} other {{replacement}}}",
   "@replacementPreview": {
     "description": "Replacement preview by replacement",
     "placeholders": {

--- a/lib/screens/settings/profile_page/profile_page_dialogs.dart
+++ b/lib/screens/settings/profile_page/profile_page_dialogs.dart
@@ -66,7 +66,7 @@ class TextModifierDialog extends StatelessWidget {
         caseSensitive: false,
       );
     } else {
-      editModifier = sourceModifier.copyWith();
+      editModifier = sourceModifier;
     }
   }
 


### PR DESCRIPTION
fix:
 - Existing modifier not being updated when modified\
because the value passed on editModifier was a new instance of TextModifier instead of the reference to the existing TextModifier
 - ICU's Select syntax for replacement preview of TextModifier,\
previously it shows the word "replacement" instead of the value of the replacement variable