### PR TITLE
fix:  Remove await on muxing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Automatically manage and mux series or movie files to the common conventions use
 1. Run mkv_profile.exe to launch app
 
 - **Installer (MSIX)**
-    - Note: Requires Certificate Installation
+    - Note: Requires Certificate Installation (first time only or if previously removed)
 1. Head to the downloaded msix file
 1. Right click and select properties
 1. From the properties dialog, select Digital Signatures tab
@@ -39,7 +39,7 @@ Automatically manage and mux series or movie files to the common conventions use
 
 ## Available Profile Configurations
 - Show (Movie / Series) Title Formats
-    - ***Example:*** %show_title%% (year)%
+    - ***Example:*** `%show_title%% (year)%`
 
     |Data|Variable|
     |:-|:-|
@@ -52,7 +52,7 @@ Automatically manage and mux series or movie files to the common conventions use
     |Width|`%width%`|
     |Year|`%year%`|
 - Video Title Formats
-    - ***Example:*** %show_title%% - Sseason_number%%Eepisode_number%% - episode_title%
+    - ***Example:*** `%show_title%% - Sseason_number%%Eepisode_number%% - episode_title%`
 
     |Data|Variable|
     |:-|:-|
@@ -84,7 +84,7 @@ Automatically manage and mux series or movie files to the common conventions use
     |Visual Impaired|`%visual_impaired%`|
     |Text Description|`%text_description%`|
 - Subtitle Title Formats
-    - ***Example:*** %language%% (hearing_impaired)%% (forced)%
+    - ***Example:*** `%language%% (hearing_impaired)%% (forced)%`
 
     |Data|Variable|
     |:-|:-|
@@ -120,10 +120,10 @@ otherwise if empty, will return  `Tom Clancy's Jack Ryan - S01E01`
 ## Available Track Options (Video/Audio/Subtitle)
 - Title
 - Language
-- **Flags** [Default, Original Language, Forced, Commentary, Hearing Impaired, Visual Impaired, Text Description]
+- **Flags** [Enabled, Default, Original Language, Forced, Commentary, Hearing Impaired, Visual Impaired, Text Description]
 - Extra Options field for [mkvmerge commands](https://mkvtoolnix.download/doc/mkvmerge.html) (Separated by space)
     - You can use the variable %id% to access the track id in the user specified extra options
-    - e.g. --track-enabled-flag %id%:true --no-track-tags --no-global-tags
+    - e.g. `--default-duration %id%:23.976fps --no-track-tags --no-global-tags`
 ## Available Video Options
 - No Chapters
 - No Attachments
@@ -158,7 +158,7 @@ This app rely on the third party tools [MediaInfo](https://mediaarea.net/en/Medi
 This project uses self signed certificate because trusted signed certificates from services comes with a cost which isn't reasonable for a FOSS project.
 If you have doubts about the certificate, [Read more here](https://github.com/harlanx/mkv_profile/blob/93f22cf071d54826499b63e9d6869b6ac00384a4/pubspec.yaml#L76C1-L76C108)
 
-## Third party tools path is default but it's not working?
+## Third party tools path is default but its not working?
 The saved path was probably from an old installation, to reset it or entirely clear old app data:
 - **Reset Tool Path**
     - Head to Settings
@@ -171,7 +171,7 @@ The saved path was probably from an old installation, to reset it or entirely cl
     - Find the folder that contains the word `harlanx` or the folder inside it named `MKV Profile` then delete it
     - Reopen the app
     - The path will be set to the default path of the third party binaries that comes with the app
-## Updated the app, now it's showing white screen?
+## Updated the app, now its showing white screen?
 - **Manually Migrate Old App Settings to New**
     - Head to C:\Users\\`<Username>`\AppData\Roaming **or** C:\Users\\`<Username>`\AppData\Local\Packages
     - Find the folder that contains the word `harlanx`

--- a/lib/data/app_settings_notifier.dart
+++ b/lib/data/app_settings_notifier.dart
@@ -273,7 +273,7 @@ class AppSettingsNotifier extends ChangeNotifier {
         tooltipTheme: const TooltipThemeData(
           padding: EdgeInsets.all(8),
           showDuration: Duration.zero,
-          waitDuration: Duration.zero,
+          waitDuration: Duration(milliseconds: 300),
         ),
         infoBarTheme: InfoBarThemeData(
           decoration: (severity) {
@@ -319,7 +319,7 @@ class AppSettingsNotifier extends ChangeNotifier {
         tooltipTheme: const TooltipThemeData(
           padding: EdgeInsets.all(8),
           showDuration: Duration.zero,
-          waitDuration: Duration.zero,
+          waitDuration: Duration(milliseconds: 300),
         ),
         infoBarTheme: InfoBarThemeData(
           decoration: (severity) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 
@@ -34,18 +35,19 @@ void main() async {
   );
 
   // Causes app frame freeze on hot reload or hot restart so don't await this one.
-  // ignore: unawaited_futures
-  windowManager.waitUntilReadyToShow(windowOptions, () async {
-    await windowManager.setPreventClose(true);
-    if (AppData.appSettings.isMaximized) {
-      await windowManager.maximize();
-    }
+  unawaited(
+    windowManager.waitUntilReadyToShow(windowOptions, () async {
+      await windowManager.setPreventClose(true);
+      if (AppData.appSettings.isMaximized) {
+        await windowManager.maximize();
+      }
 
-    // Handles default title bar theme changes at startup
-    // await windowManager.setBrightness(
-    //   SystemTheme.isDarkMode ? Brightness.dark : Brightness.light,
-    // );
-  });
+      // Handles default title bar theme changes at startup
+      // await windowManager.setBrightness(
+      //   SystemTheme.isDarkMode ? Brightness.dark : Brightness.light,
+      // );
+    }),
+  );
   // Disables any printing in production.
   if (kReleaseMode) {
     debugPrint = (String? message, {int? wrapWidth}) {};

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -82,6 +82,7 @@ class UserProfile extends ChangeNotifier with EquatableMixin {
       id: 0,
       replaceables: [
         'GalaxyRG',
+        'GalaxyTV',
         'Infinity',
         'Complete',
         'Subbed',
@@ -92,6 +93,7 @@ class UserProfile extends ChangeNotifier with EquatableMixin {
         'ION265',
         'ION10',
         'XEBEC',
+        'PCOK',
         'BDRip',
         'Dolby',
         'Atmos',

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart' as mt;
 import 'package:fluent_ui/fluent_ui.dart';
 
 import 'package:desktop_drop/desktop_drop.dart';
@@ -789,6 +790,55 @@ class _VideoNodeState extends State<VideoNode> {
                     ];
                   },
                 ),
+                if (widget.video.embeddedChapters.isNotEmpty ||
+                    widget.video.embeddedAttachments.isNotEmpty) ...[
+                  const MenuFlyoutSeparator(),
+                  if (widget.video.embeddedChapters.isNotEmpty)
+                    MenuFlyoutItem(
+                      leading: Icon(
+                        mt.Icons.label_off_rounded,
+                        color: widget.video.removeChapters
+                            ? theme.accentColor
+                                .defaultBrushFor(theme.brightness)
+                            : theme.inactiveColor,
+                      ),
+                      text: Text(l10n.removeChapters),
+                      onPressed: () {
+                        Flyout.maybeOf(
+                                Flyout.of(context).rootFlyout.currentContext!)
+                            ?.close();
+                        widget.video.removeChapters =
+                            !widget.video.removeChapters;
+                        for (final chapter in widget.video.embeddedChapters) {
+                          chapter.include = !widget.video.removeChapters;
+                        }
+                        notifier.refresh();
+                      },
+                    ),
+                  if (widget.video.embeddedAttachments.isNotEmpty)
+                    MenuFlyoutItem(
+                      leading: Icon(
+                        mt.Icons.link_off_rounded,
+                        color: widget.video.removeAttachments
+                            ? theme.accentColor
+                                .defaultBrushFor(theme.brightness)
+                            : theme.inactiveColor,
+                      ),
+                      text: Text(l10n.removeAttachments),
+                      onPressed: () {
+                        Flyout.maybeOf(
+                                Flyout.of(context).rootFlyout.currentContext!)
+                            ?.close();
+                        widget.video.removeAttachments =
+                            !widget.video.removeAttachments;
+                        for (final attachment
+                            in widget.video.embeddedAttachments) {
+                          attachment.include = !widget.video.removeAttachments;
+                        }
+                        notifier.refresh();
+                      },
+                    ),
+                ],
               ],
             );
           },
@@ -1788,20 +1838,22 @@ class _ExtraNodeState extends State<ExtraNode> {
           builder: (context) {
             return MenuFlyout(
               items: [
-                MenuFlyoutItem(
-                  leading: Icon(
-                    embedded ? FluentIcons.link : FluentIcons.add_link,
-                    color: widget.extra.include
-                        ? theme.accentColor.defaultBrushFor(theme.brightness)
-                        : theme.inactiveColor,
+                if (!embedded) ...[
+                  MenuFlyoutItem(
+                    leading: Icon(
+                      FluentIcons.add_link,
+                      color: widget.extra.include
+                          ? theme.accentColor.defaultBrushFor(theme.brightness)
+                          : theme.inactiveColor,
+                    ),
+                    text: Text(l10n.include),
+                    onPressed: () {
+                      Flyout.of(context).close();
+                      widget.extra.update(include: !widget.extra.include);
+                      notifier.refresh();
+                    },
                   ),
-                  text: Text(l10n.include),
-                  onPressed: () {
-                    Flyout.of(context).close();
-                    widget.extra.update(include: !widget.extra.include);
-                    notifier.refresh();
-                  },
-                ),
+                ],
                 MenuFlyoutItem(
                   leading: const Icon(FluentIcons.edit),
                   text: Text(l10n.edit),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -506,8 +506,7 @@ class _SeasonNodeState extends State<SeasonNode> {
       child: CustomExpander(
         initiallyExpanded: expand,
         animationDuration: Duration.zero,
-        headerHeight: 30,
-        levelPadding: 0.0,
+        headerPadding: EdgeInsetsDirectional.zero,
         onStateChanged: (value) {
           if (value) {
             notifier.expandedNodes.add(expandKey);
@@ -816,8 +815,7 @@ class _VideoNodeState extends State<VideoNode> {
               child: CustomExpander(
                 initiallyExpanded: expand,
                 animationDuration: Duration.zero,
-                headerHeight: 30,
-                levelPadding: videoPadding,
+                headerPadding: EdgeInsetsDirectional.only(start: videoPadding),
                 onStateChanged: (value) {
                   if (value) {
                     notifier.expandedNodes.add(widget.video.mainFile.path);
@@ -988,8 +986,7 @@ class _AudioNodesState extends State<AudioNodes> {
       child: CustomExpander(
         initiallyExpanded: expand,
         animationDuration: Duration.zero,
-        headerHeight: 30,
-        levelPadding: widget.trackPadding,
+        headerPadding: EdgeInsetsDirectional.only(start: widget.trackPadding),
         onStateChanged: (value) {
           if (value) {
             notifier.expandedNodes.add(expandKey);
@@ -1133,8 +1130,7 @@ class _SubtitleNodesState extends State<SubtitleNodes> {
       child: CustomExpander(
         initiallyExpanded: expand,
         animationDuration: Duration.zero,
-        headerHeight: 30,
-        levelPadding: widget.trackPadding,
+        headerPadding: EdgeInsetsDirectional.only(start: widget.trackPadding),
         onStateChanged: (value) {
           if (value) {
             notifier.expandedNodes.add(expandKey);
@@ -1275,8 +1271,7 @@ class _ChapterNodesState extends State<ChapterNodes> {
       child: CustomExpander(
         initiallyExpanded: expand,
         animationDuration: Duration.zero,
-        headerHeight: 30,
-        levelPadding: widget.trackPadding,
+        headerPadding: EdgeInsetsDirectional.only(start: widget.trackPadding),
         onStateChanged: (value) {
           if (value) {
             notifier.expandedNodes.add(expandKey);
@@ -1418,8 +1413,7 @@ class _AttachmentNodesState extends State<AttachmentNodes> {
       child: CustomExpander(
         initiallyExpanded: expand,
         animationDuration: Duration.zero,
-        headerHeight: 30,
-        levelPadding: widget.trackPadding,
+        headerPadding: EdgeInsetsDirectional.only(start: widget.trackPadding),
         onStateChanged: (value) {
           if (value) {
             notifier.expandedNodes.add(expandKey);

--- a/lib/screens/home/home_screen_dialogs.dart
+++ b/lib/screens/home/home_screen_dialogs.dart
@@ -777,7 +777,6 @@ class ExtraDialog extends StatelessWidget {
             ),
             Expander(
               header: Text(l10n.contentPreview),
-              headerHeight: 32,
               content: Container(
                 decoration: isChapter && !embedded
                     ? BoxDecoration(

--- a/lib/screens/home/home_screen_dialogs.dart
+++ b/lib/screens/home/home_screen_dialogs.dart
@@ -299,6 +299,7 @@ class _VideoTitleDialogState extends State<VideoTitleDialog> {
             color: Colors.transparent,
             child: Wrap(
               direction: Axis.horizontal,
+              crossAxisAlignment: WrapCrossAlignment.center,
               runSpacing: 6,
               spacing: 6,
               children: [
@@ -347,40 +348,54 @@ class _VideoTitleDialogState extends State<VideoTitleDialog> {
                     },
                   ),
                 ],
-                ValueListenableBuilder<bool>(
-                  valueListenable: removeChapters,
-                  builder: (context, value, child) {
-                    return Tooltip(
-                      message: l10n.remove_chapters_description,
-                      child: mt.ChoiceChip(
-                        avatar: const Icon(mt.Icons.label_off_rounded),
-                        label: Text(l10n.removeChapters),
-                        selected: value,
-                        selectedColor: theme.accentColor,
-                        onSelected: (val) {
-                          removeChapters.value = val;
-                        },
+                if (widget.v.embeddedChapters.isNotEmpty ||
+                    widget.v.embeddedAttachments.isNotEmpty) ...[
+                  Divider(
+                    direction: Axis.vertical,
+                    size: 15,
+                    style: theme.dividerTheme.merge(
+                      const DividerThemeData(
+                        verticalMargin: EdgeInsets.symmetric(vertical: 3),
                       ),
-                    );
-                  },
-                ),
-                ValueListenableBuilder<bool>(
-                  valueListenable: removeAttachments,
-                  builder: (context, value, child) {
-                    return Tooltip(
-                      message: l10n.remove_attachments_description,
-                      child: mt.ChoiceChip(
-                        avatar: const Icon(mt.Icons.link_off_rounded),
-                        label: Text(l10n.removeAttachments),
-                        selected: value,
-                        selectedColor: theme.accentColor,
-                        onSelected: (val) {
-                          removeAttachments.value = val;
-                        },
-                      ),
-                    );
-                  },
-                ),
+                    ),
+                  ),
+                  if (widget.v.embeddedChapters.isNotEmpty)
+                    ValueListenableBuilder<bool>(
+                      valueListenable: removeChapters,
+                      builder: (context, value, child) {
+                        return Tooltip(
+                          message: l10n.remove_chapters_description,
+                          child: mt.ChoiceChip(
+                            avatar: const Icon(mt.Icons.label_off_rounded),
+                            label: Text(l10n.removeChapters),
+                            selected: value,
+                            selectedColor: theme.accentColor,
+                            onSelected: (val) {
+                              removeChapters.value = val;
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                  if (widget.v.embeddedAttachments.isNotEmpty)
+                    ValueListenableBuilder<bool>(
+                      valueListenable: removeAttachments,
+                      builder: (context, value, child) {
+                        return Tooltip(
+                          message: l10n.remove_attachments_description,
+                          child: mt.ChoiceChip(
+                            avatar: const Icon(mt.Icons.link_off_rounded),
+                            label: Text(l10n.removeAttachments),
+                            selected: value,
+                            selectedColor: theme.accentColor,
+                            onSelected: (val) {
+                              removeAttachments.value = val;
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                ],
               ],
             ),
           ),

--- a/lib/screens/test/test_screen.dart
+++ b/lib/screens/test/test_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:isolate';
 
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/material.dart' as material;
 
 class TestScreen extends StatefulWidget {
   const TestScreen({Key? key}) : super(key: key);
@@ -98,6 +99,25 @@ class _TestScreenState extends State<TestScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              TooltipTheme(
+                data: const TooltipThemeData(
+                  waitDuration: Duration.zero,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    for (final color in material.Colors.primaries)
+                      Tooltip(
+                        message: color.toString(),
+                        child: Container(
+                          color: color,
+                          height: 25,
+                          width: 25,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
               const ProgressBar(),
               Text(value),
               const Expander(

--- a/lib/services/show_merger.dart
+++ b/lib/services/show_merger.dart
@@ -192,34 +192,36 @@ class ShowMerger {
       }
 
       debugPrint('Processing Item:${video.fileTitle}');
-      await _processVideo(
-        video,
-        folder,
-        tln,
-        tn,
-        result,
-        videoPercents,
-        videoStatuses,
-        mainCompleter,
-      ).then((_) {
-        runningProcesses--;
+      unawaited(
+        _processVideo(
+          video,
+          folder,
+          tln,
+          tn,
+          result,
+          videoPercents,
+          videoStatuses,
+          mainCompleter,
+        ).then((_) {
+          runningProcesses--;
 
-        if (queue.isNotEmpty) {
-          final completer = queue.removeFirst();
-          completer.complete();
-        }
-        if (tn.completed == tn.total) {
-          // Process completed, fulfill the completer with the info
-          if (videoStatuses.values
-              .every((status) => status == TaskStatus.completed)) {
-            result.taskStatus = TaskStatus.completed;
-          } else {
-            result.taskStatus = TaskStatus.error;
+          if (queue.isNotEmpty) {
+            final completer = queue.removeFirst();
+            completer.complete();
           }
+          if (tn.completed == tn.total) {
+            // Process completed, fulfill the completer with the info
+            if (videoStatuses.values
+                .every((status) => status == TaskStatus.completed)) {
+              result.taskStatus = TaskStatus.completed;
+            } else {
+              result.taskStatus = TaskStatus.error;
+            }
 
-          mainCompleter.complete(result);
-        }
-      });
+            mainCompleter.complete(result);
+          }
+        }),
+      );
 
       runningProcesses++;
     }

--- a/lib/services/title_scanner.dart
+++ b/lib/services/title_scanner.dart
@@ -18,12 +18,13 @@ class TitleScanner {
 
   /// Title scanner by replacing the matched strings using the list [UserProfile.modifiers]
   static String _showTitle(String source, List<TextModifier> modifiers) {
-    var fileTitle =
-        source.split(RegExp(r'Episode.\d+|E.\d+|Episode \d+|E \d+')).first;
+    var fileTitle = source
+        .split(RegExp(r'(?:E(?:pisode)?\.?\s?\d{2}|Episode(?:\s?\d{2})?)\b'))
+        .first;
     for (var i in modifiers) {
       for (var j in i.replaceables) {
         fileTitle = fileTitle.replaceAll(
-            RegExp(j.regexSafe, caseSensitive: i.caseSensitive), i.replacement);
+            RegExp(j.regexSafe, caseSensitive: false), i.replacement);
       }
     }
 
@@ -38,8 +39,8 @@ class TitleScanner {
   /// Title scanner by replacing the matched strings using the list [UserProfile.modifiers]
   static String _episodeTitle(String source, List<TextModifier> modifiers) {
     var episodeTitle = '';
-    final possibleTitles =
-        source.split(RegExp(r'Episode.\d+|E.\d+|Episode \d+|E \d+'));
+    final possibleTitles = source
+        .split(RegExp(r'(?:E(?:pisode)?\.?\s?\d{2}|Episode(?:\s?\d{2})?)\b'));
     if (possibleTitles.length >= 2) {
       episodeTitle = possibleTitles.last;
       for (var i in modifiers) {
@@ -74,6 +75,8 @@ class TitleScanner {
     final show = input.show;
     final rawTitle = _sourceTitle(show, profile);
     String titleFormat = profile.showTitleFormat;
+
+    if (titleFormat.isEmpty) return rawTitle;
 
     MediaInfo info;
     if (show is Movie) {

--- a/lib/utilities/custom_widgets/fluent_appbar.dart
+++ b/lib/utilities/custom_widgets/fluent_appbar.dart
@@ -8,8 +8,11 @@ import '../../data/app_data.dart';
 /// It is not the same as the generic title bar for windows which can also be
 /// configured with the window_manager package.
 class FluentAppBar extends NavigationAppBar {
-  FluentAppBar({required this.context})
-      : super(
+  FluentAppBar({
+    Key? key,
+    required BuildContext context,
+  }) : super(
+          key: key,
           automaticallyImplyLeading: false,
           actions: const WindowButtons(),
           height: 34,
@@ -31,7 +34,6 @@ class FluentAppBar extends NavigationAppBar {
             ),
           ),
         );
-  final BuildContext context;
 }
 
 class WindowButtons extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: "direct main"
     description:
       name: fluent_ui
-      sha256: be237134ab215d4a1591307f6286f4aa53ed5a492c2ee56be5d86be344fd16db
+      sha256: "9957c04c0b73f366f94dea1422c80c2c21511453e727d7b1b5836dc457add5bf"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.7.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -417,10 +417,10 @@ packages:
     dependency: "direct dev"
     description:
       name: msix
-      sha256: "927c207656dc92eaf3d005c734d259c4ede440052a7281f9e1cc8966ffdbf1c7"
+      sha256: "76c87b8207323803169626a55afd78bbb8413c984df349a76598b9fbf9224677"
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.0"
+    version: "3.16.1"
   multi_split_view:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Automatically manage and mux series or movie files to the common co
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.6.1+20
+version: 0.6.2+21
 
 environment:
   sdk: ">=2.19.0 <3.0.0"


### PR DESCRIPTION
fix:
 - Remove await on `_processVideo` to restore parallel processing\
this bug was introduced by GH-2. Awaiting futures depends on usage, `_processVideo` in `mergeMethodA` should not be awaited but `_processVideo` in `mergeMethodB` should be awaited.

feat:
 - Use new pattern to split title for possible episode title
 - Make `Remove Chapter` & `Remove Attachments` conditional\
 to only show when there are embedded tracks of it

chore:
 - Refactor unawaited future
 - Refactor AppBar local variables
 - Add new replaceables for default textmodifiers
 - Update dependencies and custom widgets
 - Update documentation
 - Bump app version to 0.6.2+21