### PR TITLE
ci: Exclude unnecessary files included in setup

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -32,18 +32,12 @@ jobs:
               run: flutter --version
             - name: Enable windows build
               run: flutter config --enable-windows-desktop
-            - name: Build windows release artifacts
+            - name: Create release artifacts
               run: flutter build windows --release
             - name: Archive and compress release artifacts
               run: |
                 $outputPath = "build\windows\runner\Release\mkv_profile-${{ env.APP_VERSION }}-windows.zip"
                 Compress-Archive -Path "build\windows\runner\Release\*" -DestinationPath $outputPath
-            - name: Create exe installer
-              run: |
-                "%ProgramFiles(x86)%\Inno Setup 6\iscc.exe" `
-                /dMyAppVersion="${{ env.APP_VERSION }}" `
-                "inno_setup.iss"
-              shell: cmd
             - name: Create msix installer
               run: |
                 dart run msix:create `
@@ -51,6 +45,12 @@ jobs:
                 --certificate-path=${{ github.workspace }}/keys/CERTIFICATE.pfx `
                 --output-path=build/windows/runner/Release `
                 --output-name=mkv_profile-${{env.APP_VERSION}}-windows
+            - name: Create exe installer
+              run: |
+                "%ProgramFiles(x86)%\Inno Setup 6\iscc.exe" `
+                /dMyAppVersion="${{ env.APP_VERSION }}" `
+                "inno_setup.iss"
+              shell: cmd
             - name: Upload to Github release
               uses: softprops/action-gh-release@v1
               env:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Automatically manage and mux series or movie files to the common conventions use
 1. Run mkv_profile.exe to launch app
 
 - **Setup (EXE)**
+    - Note: Requires Instllation of Latest [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) (if not yet installed)
 1. Head to the downloaded executable setup file
 1. Run setup as administrator
 1. Follow the rest of the installation steps within the setup window
@@ -160,7 +161,7 @@ This app rely on the third party tools [MediaInfo](https://mediaarea.net/en/Medi
 
 ## Why do I have to install the certificate before installing?
 This project uses self signed certificate because trusted signed certificates from services comes with a cost which isn't reasonable for a FOSS project.
-If you have doubts about the certificate, [Read more here](https://github.com/harlanx/mkv_profile/blob/93f22cf071d54826499b63e9d6869b6ac00384a4/pubspec.yaml#L76C1-L76C108)
+To see how the certificate was created. [Read more here](https://docs.flutter.dev/platform-integration/windows/building#msix-packaging)
 
 ## Third party tools path is default but its not working?
 The saved path was probably from an old installation, to reset it or entirely clear old app data:

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -36,7 +36,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: ".\build\windows\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\build\windows\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\build\windows\runner\Release\*"; DestDir: "{app}"; Excludes: "*.zip,*.msix"; Flags: ignoreversion
 Source: ".\build\windows\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,9 +93,10 @@ msix_config:
   # where they can run the app portably.
   # The link below is the instruction for installing certificate.
   # https://diyusthad.com/2022/10/solved-untrusted-certificate-when-installing-msix-build-using-flutter.html
-  # If anyone had doubts on the certificate, this is how it was created.
-  # https://sahajrana.medium.com/how-to-generate-a-pfx-certificate-for-flutter-windows-msix-lib-a860cdcebb8
-  # Can be manually typed it in but in my case it has been set up in repo secrets and specified only on github actions
+  # The self signed certificate was created by following the official guide from flutter docs
+  # https://docs.flutter.dev/platform-integration/windows/building#msix-packaging
+  # Path and password can be manually typed it in during testing, for deployment it has been set up in
+  # repo secrets and specified only on github actions
   certificate_path:
   certificate_password:
   sign_msix: true


### PR DESCRIPTION
ci:
 - Exclude zip and msix builds from the inno setup script

docs:
 - Additional note for the setup installer\
Following the deployment guide from [Building your own zip file for Windows](https://docs.flutter.dev/platform-integration/windows/building#building-your-own-zip-file-for-windows) and [Using the Visual C++ Redistributable Package Walkthrough](https://learn.microsoft.com/en-us/cpp/windows/deploying-visual-cpp-application-by-using-the-vcpp-redistributable-package?view=msvc-170)