### PR TITLE
ci: Fix inno setup build

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -48,9 +48,8 @@ jobs:
             - name: Create exe installer
               run: |
                 "%ProgramFiles(x86)%\Inno Setup 6\iscc.exe" `
-                /dMyAppVersion="${{ env.APP_VERSION }}" `
+                /DMyAppVersion="${{ env.APP_VERSION }}" `
                 "inno_setup.iss"
-              shell: cmd
             - name: Upload to Github release
               uses: softprops/action-gh-release@v1
               env:

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -21,9 +21,9 @@ DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
-OutputDir=.\build\windows\runner\Release
+OutputDir={#SourcePath}\build\windows\runner\Release
 OutputBaseFilename=mkv_profile-{#MyAppVersion}-setup-windows
-SetupIconFile=.\windows\runner\resources\app_icon.ico
+SetupIconFile={#SourcePath}\windows\runner\resources\app_icon.ico
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
@@ -35,9 +35,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: ".\build\windows\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\build\windows\runner\Release\*"; DestDir: "{app}"; Excludes: "*.zip,*.msix"; Flags: ignoreversion
-Source: ".\build\windows\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SourcePath}\build\windows\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourcePath}\build\windows\runner\Release\*"; DestDir: "{app}"; Excludes: "*.zip,*.msix"; Flags: ignoreversion
+Source: "{#SourcePath}\build\windows\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
ci:
 - Fix relative path for source path and use the predefined variable from inno setup preprocessor to get the main directory of the project.\
The path it provides is the where the script resides.
 - Fix the parameter which emulates #define in the script\
The runner was also changed into powershell