### PR TITLE
ci: Improve msix installer

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Enable windows build
               run: flutter config --enable-windows-desktop
             - name: Create release build
-              run: flutter build windows --release
+              run: flutter build windows --release --obfuscate --split-debug-info=build/windows/runner/Outputs/symbols
             - name: Create portable zip
               run: |
                 $outputPath = "build/windows/runner/Outputs/mkv_profile-${{ env.APP_VERSION }}-windows.zip"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -32,20 +32,22 @@ jobs:
               run: flutter --version
             - name: Enable windows build
               run: flutter config --enable-windows-desktop
-            - name: Create release artifacts
+            - name: Create release build
               run: flutter build windows --release
-            - name: Archive and compress release artifacts
+            - name: Create portable zip
               run: |
-                $outputPath = "build\windows\runner\Release\mkv_profile-${{ env.APP_VERSION }}-windows.zip"
-                Compress-Archive -Path "build\windows\runner\Release\*" -DestinationPath $outputPath
+                $outputPath = "build/windows/runner/Outputs/mkv_profile-${{ env.APP_VERSION }}-windows.zip"
+                Compress-Archive -Path "build/windows/runner/Release/*" -DestinationPath $outputPath
+            # We already called build so we skip it in msix to reduce work for the runner
             - name: Create msix installer
               run: |
                 dart run msix:create `
+                --build-windows=false `
                 --certificate-password=${{ secrets.CERTIFICATE_PASSWORD }} `
                 --certificate-path=${{ github.workspace }}/keys/CERTIFICATE.pfx `
-                --output-path=build/windows/runner/Release `
+                --output-path=build/windows/runner/Outputs `
                 --output-name=mkv_profile-${{env.APP_VERSION}}-windows
-            - name: Create exe installer
+            - name: Create exe setup installer
               run: |
                 "%ProgramFiles(x86)%\Inno Setup 6\iscc.exe" ^
                 /DMyAppVersion="${{ env.APP_VERSION }}" ^
@@ -59,6 +61,6 @@ jobs:
                 tag_name: v${{ env.APP_VERSION }}
                 generate_release_notes: true
                 files: |
-                  build/windows/runner/Release/mkv_profile-${{ env.APP_VERSION }}-windows.zip
-                  build/windows/runner/Release/mkv_profile-${{ env.APP_VERSION }}-setup-windows.exe
-                  build/windows/runner/Release/mkv_profile-${{ env.APP_VERSION }}-windows.msix
+                  build/windows/runner/Outputs/mkv_profile-${{ env.APP_VERSION }}-windows.zip
+                  build/windows/runner/Outputs/mkv_profile-${{ env.APP_VERSION }}-setup-windows.exe
+                  build/windows/runner/Outputs/mkv_profile-${{ env.APP_VERSION }}-windows.msix

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -21,7 +21,7 @@ DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
-OutputDir={#SourcePath}\build\windows\runner\Release
+OutputDir={#SourcePath}\build\windows\runner\Outputs
 OutputBaseFilename=mkv_profile-{#MyAppVersion}-setup-windows
 SetupIconFile={#SourcePath}\windows\runner\resources\app_icon.ico
 Compression=lzma
@@ -36,7 +36,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "{#SourcePath}\build\windows\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#SourcePath}\build\windows\runner\Release\*"; DestDir: "{app}"; Excludes: "*.zip,*.msix"; Flags: ignoreversion
+Source: "{#SourcePath}\build\windows\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#SourcePath}\build\windows\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,3 +106,4 @@ msix_config:
   capabilities: "videosLibrary,documentsLibrary,codeGeneration"
   # Don't publish to Microsoft Store
   store: false
+  windows_build_args: --obfuscate --split-debug-info=build/windows/runner/Debug

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,4 +106,3 @@ msix_config:
   capabilities: "videosLibrary,documentsLibrary,codeGeneration"
   # Don't publish to Microsoft Store
   store: false
-  windows_build_args: --obfuscate --split-debug-info=build/windows/runner/Debug


### PR DESCRIPTION
ci:
 - Fix msic including the created portable zip file
 - Obfuscate code and split debug info
These two reduces the size of the deployed builds